### PR TITLE
Update README, package-requires, package-lint, byte-compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 *View a simple summary of an NOAA weather forecast*
 
-The [NOAA](http://www.noaa.gov) exposes a number of services which provide weather-related data. **noaa.el** provides an interface for viewing forecast data at api.weather.gov.
+The [NOAA](http://www.noaa.gov) exposes a number of services which
+provide weather-related data. **noaa.el** provides an interface for
+viewing USA forecast data at api.weather.gov.
 
 ---
 
@@ -22,6 +24,9 @@ If `calendar-latitude` and `calendar-latitude` are already defined, those values
 	(setq noaa-latitude 45)
 	(setq noaa-longitude 120)
 
+NOAA accepts coordinates as floating point numbers with up to four
+digits of precision (eg. 45.1234).
+
 ## Use
 
 1. Use <kbd>M-x</kbd> `noaa` to invoke `noaa`.
@@ -30,9 +35,29 @@ If `calendar-latitude` and `calendar-latitude` are already defined, those values
 
 ### Additional notes on use
 
-- An hourly forecast can be accessed via `noaa-hourly`.
+- The header line lists useful keybindings
 
-- Use the <kbd>n</kbd> key to cycle through views of the forecast which vary in terms of verbosity
+  - <kbd>n</kbd> to cycle through forecast view styles
+
+  - <kbd>h</kbd> to view an hourly forecast
+
+  - <kbd>d</kbd> to view a daily forecast (the default)
+
+  - <kbd>c</kbd> to view a forecast for a different USA location.
+
+    - You can enter a CITY, ST location string, or if you just press
+      <kbd>enter</kbd> you'll be prompted for latitude and longitude
+      coordinates.
+
+  - <kbd>q</kbd> to quit
+
+## Customization
+
+The default forecast presentation styles don't present *all* of the
+possible data available from NOAA. You can customize the styles to
+suit your needs by modifying variables `noaa-daily-styles` and
+`noaa-hourly-styles` with reference to the NOAA api. Two useful
+reference URLs are indicated in the source code.
 
 ## License
 

--- a/noaa.el
+++ b/noaa.el
@@ -1,12 +1,12 @@
 ;;; noaa.el --- Get NOAA weather data -*- lexical-binding: t -*-
 
-;; Copyright (C) 2017,2018 David Thompson
+;; Copyright (C) 2017,2018, 2021 David Thompson
 ;; Author: David Thompson
 ;; Version: 0.1
-;; Keywords:
+;; Keywords: calendar
 ;; Homepage: https://github.com/thomp/noaa
 ;; URL: https://github.com/thomp/noaa
-;; Package-Requires: ((request "0.2.0") (cl-lib "0.5") (emacs "24") (dash "2.14.1"))
+;; Package-Requires: ((emacs "27.1") (request "0.2.0") (dash "2.14.1"))
 
 ;;; Commentary:
 
@@ -21,7 +21,6 @@
 ;;; Code:
 
 (require 'cl-lib)
-(require 'cl-macs)    ; cl-function
 (require 'cl-extra)   ; cl-concatenate
 (require 'dash)
 (require 'json)
@@ -178,7 +177,7 @@ Shortcut for M-x `noaa' with a prefix argument."
 NUM is a string representation of a floating point number."
   (replace-regexp-in-string "\\.\\(....\\).*" ".\\1" num))
 
-(cl-defun noaa--osm-callback (&key data response error-thrown &allow-other-keys)
+(cl-defun noaa--osm-callback (&key data _response _error-thrown &allow-other-keys)
   (unless data
     (error "No data returned from openstreetmap.org"))
   (condition-case nil
@@ -254,8 +253,7 @@ forecast described by the value of NOAA-LAST-FORECAST-SET."
 		  (setf (noaa-forecast-name (elt (noaa-forecast-set-forecasts forecast-set) index))
 			this-forecast-name)
 		  t)
-		 (t nil))
-	   ))))))
+		 (t nil))))))))
 
 (defun noaa-forecast-hourly-p (forecast)
   "Return T if the set of forecast structs described by FORECAST seems to represent an hourly forecast."


### PR DESCRIPTION
This is all minor with the exception that `package-lint` warned that using function `json-parse-string` requires emacs version 27, which reduces the package's compatibiliy. If you want to maintain backward compatibility for older emacs versions, then an alternative needs to be found for that.